### PR TITLE
Makes luarocks install the latest code from master

### DIFF
--- a/nnx-0.1-1.rockspec
+++ b/nnx-0.1-1.rockspec
@@ -1,9 +1,9 @@
 package = "nnx"
-version = "0.1-0"
+version = "0.1-1"
 
 source = {
    url = "git://github.com/clementfarabet/lua---nnx",
-   tag = "0.1-0"
+   tag = "master"
 }
 
 description = {


### PR DESCRIPTION
Turns the nnx package into a rolling release install. Thus when "luarocks
install nnx" is run the latest code from the master is compiled and installed.
This free developers from having to worry about version numbers for the most
part.
