### PR TITLE
fix infinite recursion in PullTable and PushTable 

### DIFF
--- a/PullTable.lua
+++ b/PullTable.lua
@@ -58,3 +58,20 @@ function PullTable:updateGradInput(inputTable, gradOutputTable)
    end
    return self.gradInput
 end
+
+
+function PullTable:type(type, tensorCache)
+   assert(type, 'PullTable: must provide a type to convert to')
+
+   tensorCache = tensorCache or {}
+
+   -- find all tensors and convert them
+   for key,param in pairs(self) do
+       if(key ~= "_push") then
+             self[key] = nn.utils.recursiveType(param, type, tensorCache)
+   	     end
+   end
+
+   return self
+end
+

--- a/PushTable.lua
+++ b/PushTable.lua
@@ -60,4 +60,18 @@ function PushTable:updateGradInput(inputTable, gradOutputTable)
 end
 
 
+function PushTable:type(type, tensorCache)
+   assert(type, 'PullTable: must provide a type to convert to')
+
+   tensorCache = tensorCache or {}
+
+   -- find all tensors and convert them
+   for key,param in pairs(self) do
+       if(key ~= "_pulls") then
+             self[key] = nn.utils.recursiveType(param, type, tensorCache)
+        end
+   end
+   return self
+end
+
 


### PR DESCRIPTION
Since PushTable and corresponding PullTable instances point to eachother, type casting the modules results in an infinite recursion, as you do a depth-first-search of their respective datastructures. This simple fix prevents that. 
