### PR TITLE
Change maximal tensor size in test

### DIFF
--- a/test/test-all.lua
+++ b/test/test-all.lua
@@ -89,8 +89,8 @@ local function template_SpatialReSamplingEx(up, mode)
       end
       local xratio, yratio
       if up then
-         xratio = torch.uniform(1.5, 10)
-         yratio = torch.uniform(1.5, 10)
+         xratio = torch.uniform(1.5, 5)
+         yratio = torch.uniform(1.5, 5)
       else
          xratio = torch.uniform(0.41, 0.7)
          yratio = torch.uniform(0.41, 0.7)


### PR DESCRIPTION
With the previous setting, the output size of the module could be quite large, and the Jacobian test below (which uses O(N*M) memory for N, M the module in/output size) could run out of memory (taking up to several GB).