### PR TITLE
Adding QDRiemaNNLinear, a module for Riemannian gradient descent with the Outer Product metric

### DIFF
--- a/QDRiemaNNLinear.lua
+++ b/QDRiemaNNLinear.lua
@@ -1,0 +1,55 @@
+--
+-- Author: Gaetan Marceau Caron (gaetan.marceau-caron@inria.fr)
+-- Description: Implementation of the quasi-diagonal reduction
+-- based on the Practical Riemannian Neural Networks (Yann Ollivier and Gaetan Marceau Caron) paper (http://arxiv.org/abs/1602.08007)
+-- 
+local QDRiemaNNLinear, parent = torch.class('nnx.QDRiemaNNLinear', 'nn.Linear')
+
+function QDRiemaNNLinear:__init(inputSize, outputSize, gamma, qdFlag)
+   parent.__init(self,inputSize, outputSize)
+   self.qdFlag = qdFlag or true -- Flag for choosing between diagonal or quasi-diagonal reductions
+   self.gamma = gamma  or 0.01 -- update rate of the metric
+   self.matReg = 1e-12 -- numerical regularization 
+   self.initMetric = true -- flag for first update
+   self.Mii = torch.Tensor(outputSize, inputSize)
+   if self.qdFlag then self.M0i = torch.Tensor(outputSize, inputSize) end
+   self.M00 = torch.Tensor(outputSize)
+end
+
+function QDRiemaNNLinear:accGradParameters(input, gradOutput)
+   parent.accGradParameters(self,input,gradOutput)
+   
+   gradOutputSqT = torch.pow(gradOutput,2):t()
+   
+   if self.initMetric then
+	  self.Mii:mm(gradOutputSqT,torch.pow(input,2))
+	  self.M00:mv(gradOutputSqT,self.addBuffer)
+	  if self.qdFlag then self.M0i:mm(gradOutputSqT,input) end
+	  self.initMetric = false
+   else
+	  self.Mii:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,torch.pow(input,2))
+	  if self.qdFlag then self.M0i:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,input) end
+	  self.M00:mul(1.-self.gamma):addmv(self.gamma,gradOutputSqT,self.addBuffer)
+   end
+   
+   if self.qdFlag then
+	  local numerator = torch.add(torch.cmul(self.gradWeight,self.M00:view(-1,1):expandAs(self.gradWeight)), -1.0, torch.cmul(self.M0i,self.gradBias:view(-1,1):expandAs(self.M0i)))
+	  local denominator = torch.add(torch.cmul(self.Mii,self.M00:view(-1,1):expandAs(self.Mii)),-1.0,torch.pow(self.M0i,2)):clamp(self.matReg,1e25)
+	  self.gradWeight:copy(torch.cdiv(numerator,denominator))
+	  
+	  local temp = torch.cmul(torch.cdiv(self.M0i,self.M00:view(-1,1):expandAs(self.M0i)),self.gradWeight)
+	  self.gradBias:copy(torch.add(torch.cdiv(self.gradBias,self.M00),-1.0,torch.sum(temp,2)))
+   
+   else
+	  self.gradWeight:cdiv(self.Mii:add(self.matReg))
+	  self.gradBias:cdiv(self.M00:add(self.matReg))
+   end
+end
+
+function QDRiemaNNLinear:reset()
+   self.initMetric = true
+   stdv = 1./math.sqrt(self.weight:size(2))
+   self.weight:normal(0, stdv)
+   self.bias:zero()
+   return self
+end

--- a/QDRiemaNNLinear.lua
+++ b/QDRiemaNNLinear.lua
@@ -1,48 +1,63 @@
 --
--- Author: Gaetan Marceau Caron (gaetan.marceau-caron@inria.fr)
+-- Author: Gaetan Marceau Caron (gaetan.marceau-caron@inria.fr) and Yann Ollivier
 -- Description: Implementation of the quasi-diagonal reduction
--- based on the Practical Riemannian Neural Networks (Yann Ollivier and Gaetan Marceau Caron) paper (http://arxiv.org/abs/1602.08007)
+-- based on the Practical Riemannian Neural Networks paper (http://arxiv.org/abs/1602.08007)
 -- 
 local QDRiemaNNLinear, parent = torch.class('nnx.QDRiemaNNLinear', 'nn.Linear')
 
 function QDRiemaNNLinear:__init(inputSize, outputSize, gamma, qdFlag)
    parent.__init(self,inputSize, outputSize)
-   self.qdFlag = qdFlag or true -- Flag for choosing between diagonal or quasi-diagonal reductions
+   if qdFlag == nil then -- Flag for choosing between diagonal or quasi-diagonal reductions
+	  self.qdFlag = true 
+   else
+	  self.qdFlag = qdFlag
+   end
    self.gamma = gamma  or 0.01 -- update rate of the metric
    self.matReg = 1e-12 -- numerical regularization 
    self.initMetric = true -- flag for first update
    self.Mii = torch.Tensor(outputSize, inputSize)
    if self.qdFlag then self.M0i = torch.Tensor(outputSize, inputSize) end
    self.M00 = torch.Tensor(outputSize)
+   self.accGradientFlag = true
+   self.accMetricFlag = true
+end
+
+function QDRiemaNNLinear:setAccFlag(accGradientFlag,accMetricFlag)
+   self.accGradientFlag = accGradientFlag
+   self.accMetricFlag = accMetricFlag
 end
 
 function QDRiemaNNLinear:accGradParameters(input, gradOutput)
-   parent.accGradParameters(self,input,gradOutput)
-   
-   gradOutputSqT = torch.pow(gradOutput,2):t()
-   
-   if self.initMetric then
-	  self.Mii:mm(gradOutputSqT,torch.pow(input,2))
-	  self.M00:mv(gradOutputSqT,self.addBuffer)
-	  if self.qdFlag then self.M0i:mm(gradOutputSqT,input) end
-	  self.initMetric = false
-   else
-	  self.Mii:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,torch.pow(input,2))
-	  if self.qdFlag then self.M0i:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,input) end
-	  self.M00:mul(1.-self.gamma):addmv(self.gamma,gradOutputSqT,self.addBuffer)
+   if self.accGradientFlag then
+	  parent.accGradParameters(self,input,gradOutput)
    end
-   
-   if self.qdFlag then
-	  local numerator = torch.add(torch.cmul(self.gradWeight,self.M00:view(-1,1):expandAs(self.gradWeight)), -1.0, torch.cmul(self.M0i,self.gradBias:view(-1,1):expandAs(self.M0i)))
-	  local denominator = torch.add(torch.cmul(self.Mii,self.M00:view(-1,1):expandAs(self.Mii)),-1.0,torch.pow(self.M0i,2)):clamp(self.matReg,1e25)
-	  self.gradWeight:copy(torch.cdiv(numerator,denominator))
+
+   if self.accMetricFlag then
+	  local gradOutputSqT = torch.pow(gradOutput,2):t()
 	  
-	  local temp = torch.cmul(torch.cdiv(self.M0i,self.M00:view(-1,1):expandAs(self.M0i)),self.gradWeight)
-	  self.gradBias:copy(torch.add(torch.cdiv(self.gradBias,self.M00),-1.0,torch.sum(temp,2)))
-   
-   else
-	  self.gradWeight:cdiv(self.Mii:add(self.matReg))
-	  self.gradBias:cdiv(self.M00:add(self.matReg))
+	  if self.initMetric then
+		 self.Mii:mm(gradOutputSqT,torch.pow(input,2))
+		 self.M00:mv(gradOutputSqT,self.addBuffer)
+		 if self.qdFlag then self.M0i:mm(gradOutputSqT,input) end
+		 self.initMetric = false
+	  else
+		 self.Mii:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,torch.pow(input,2))
+		 if self.qdFlag then self.M0i:mul(1.-self.gamma):addmm(self.gamma,gradOutputSqT,input) end
+		 self.M00:mul(1.-self.gamma):addmv(self.gamma,gradOutputSqT,self.addBuffer)
+	  end
+	  
+	  if self.qdFlag then
+		 local numerator = torch.add(torch.cmul(self.gradWeight,self.M00:view(-1,1):expandAs(self.gradWeight)), -1.0, torch.cmul(self.M0i,self.gradBias:view(-1,1):expandAs(self.M0i)))
+		 local denominator = torch.add(torch.cmul(self.Mii,self.M00:view(-1,1):expandAs(self.Mii)),-1.0,torch.pow(self.M0i,2)):clamp(self.matReg,1e25)
+		 self.gradWeight:copy(numerator:cdiv(denominator))
+
+		 local temp = torch.cmul(self.M0i,self.gradWeight):sum(2)
+		 self.gradBias:add(-1.,temp):cdiv(torch.add(self.M00,self.matReg))
+
+	  else
+		 self.gradWeight:cdiv(self.Mii:add(self.matReg))
+		 self.gradBias:cdiv(self.M00:add(self.matReg))
+	  end
    end
 end
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ As always, the step-size must be chosen accordingly.
 Two additional arguments are also possible:
 * gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma. A default value depending on the size of the minibatches is `gamma = 1. - torch.pow(1.-1./nTraining,miniBatchSize)` where `nTraining` is the number of training examples of the dataset and `miniBatchSize` is the number of training examples per minibatch. 
 * qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
+
 This module is a straightforward implementation of the outer product gradient descent.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ Two additional arguments are also possible:
 * gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma. A default value depending on the size of the minibatches is `gamma = 1. - torch.pow(1.-1./nTraining,miniBatchSize)` where `nTraining` is the number of training examples of the dataset and `miniBatchSize` is the number of training examples per minibatch. 
 * qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
 
-To implement a natural gradient descent, one should also use a module for generating the pseudo-labels.
-
+Replacing Linear by QDRiemmaNNLinear is a straightforward implementation of the outer product gradient descent.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The algorithm is defined in Riemannian metrics for neural networks I: feedforwar
 To use this module, simply replace `nn.Linear(ninput,noutput)` with `nnx.QDRiemaNNLinear(ninput,noutput)`.
 As always, the step-size must be chosen accordingly.
 Two additional arguments are also possible:
-* gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Should be set to 1/#minibatch
+* gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma.
 * qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
 
 To implement a natural gradient descent, one should also use a module for generating the pseudo-labels.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This section includes documentation for the following objects:
   * [PushTable (and PullTable)](#nnx.PushTable) : extracts a table element and inserts it later in the network;
   * [MultiSoftMax](#nnx.MultiSoftMax) : performs a softmax over the last dimension of a 2D or 3D input;
   * [SpatialReSampling](#nnx.SpatialReSampling) : performs bilinear resampling of a 3D or 4D input image;
+  * [QDRiemaNNLinear] (#nnx.QDRiemaNNLinear) : quasi-diagonal reduction for Riemannian gradient descent
   * [Recurrent](#nnx.Recurrent) : a generalized recurrent neural network container;
-
+  
 <a name='nnx.SoftMaxTree'/>
 ### SoftMaxTree ###
 A hierarchy of parameterized log-softmaxes. Used for computing the likelihood of a leaf class. 
@@ -223,6 +224,20 @@ The input:
 The re-sampled output:
 
 ![Lenna re-sampled](doc/image/Lenna-150x150-bilinear.png) 
+
+<a name='nnx.QDRiemaNNLinear'/>
+### QDRiemaNNLinear ###
+The Quasi-Diagonal Riemannian Neural Network Linear (QDRiemaNNLinear) module is an implementation
+of the quasi-diagonal reduction of metrics, used for Riemannian gradient descent.
+The algorithm is defined in http://arxiv.org/abs/1303.0818 and an efficient implementation is described in http://arxiv.org/abs/1602.08007.
+To use this module, simply replace nn.Linear(ninput,noutput) with nnx.QDRiemaNNLinear(ninput,noutput).
+As always, the step-size must be chosen accordingly.
+Two other arguments are also possible:
+gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Should be set to 1/#minibatch
+qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
+
+To implement a natural gradient descent, one should also use a module for generating the pseudo-labels.
+
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -235,8 +235,7 @@ As always, the step-size must be chosen accordingly.
 Two additional arguments are also possible:
 * gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma. A default value depending on the size of the minibatches is `gamma = 1. - torch.pow(1.-1./nTraining,miniBatchSize)` where `nTraining` is the number of training examples of the dataset and `miniBatchSize` is the number of training examples per minibatch. 
 * qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
-
-Replacing Linear by QDRiemmaNNLinear is a straightforward implementation of the outer product gradient descent.
+This module is a straightforward implementation of the outer product gradient descent.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The algorithm is defined in Riemannian metrics for neural networks I: feedforwar
 To use this module, simply replace `nn.Linear(ninput,noutput)` with `nnx.QDRiemaNNLinear(ninput,noutput)`.
 As always, the step-size must be chosen accordingly.
 Two additional arguments are also possible:
-* gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma.
+* gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Smaller minibatches require a smaller gamma. A default value depending on the size of the minibatches is `gamma = 1. - torch.pow(1.-1./nTraining,miniBatchSize)` where `nTraining` is the number of training examples of the dataset and `miniBatchSize` is the number of training examples per minibatch. 
 * qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
 
 To implement a natural gradient descent, one should also use a module for generating the pseudo-labels.

--- a/README.md
+++ b/README.md
@@ -229,12 +229,12 @@ The re-sampled output:
 ### QDRiemaNNLinear ###
 The Quasi-Diagonal Riemannian Neural Network Linear (QDRiemaNNLinear) module is an implementation
 of the quasi-diagonal reduction of metrics, used for Riemannian gradient descent.
-The algorithm is defined in http://arxiv.org/abs/1303.0818 and an efficient implementation is described in http://arxiv.org/abs/1602.08007.
+The algorithm is defined in Riemannian metrics for neural networks I: feedforward networks by Yann Ollivier (http://arxiv.org/abs/1303.0818) and an efficient implementation is described in Practical Riemannian Neural Networks by Yann Ollivier and Gaetan Marceau-Caron (http://arxiv.org/abs/1602.08007).
 To use this module, simply replace nn.Linear(ninput,noutput) with nnx.QDRiemaNNLinear(ninput,noutput).
 As always, the step-size must be chosen accordingly.
-Two other arguments are also possible:
-gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Should be set to 1/#minibatch
-qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
+Two additional arguments are also possible:
+* gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Should be set to 1/#minibatch
+* qdFlag (default=true): Whether to use the quasi-diagonal reduction (true) or only the diagonal (false). The former should be better.
 
 To implement a natural gradient descent, one should also use a module for generating the pseudo-labels.
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The re-sampled output:
 The Quasi-Diagonal Riemannian Neural Network Linear (QDRiemaNNLinear) module is an implementation
 of the quasi-diagonal reduction of metrics, used for Riemannian gradient descent.
 The algorithm is defined in Riemannian metrics for neural networks I: feedforward networks by Yann Ollivier (http://arxiv.org/abs/1303.0818) and an efficient implementation is described in Practical Riemannian Neural Networks by Yann Ollivier and Gaetan Marceau-Caron (http://arxiv.org/abs/1602.08007).
-To use this module, simply replace nn.Linear(ninput,noutput) with nnx.QDRiemaNNLinear(ninput,noutput).
+To use this module, simply replace `nn.Linear(ninput,noutput)` with `nnx.QDRiemaNNLinear(ninput,noutput)`.
 As always, the step-size must be chosen accordingly.
 Two additional arguments are also possible:
 * gamma (default=0.01): determine the update rate of the metric for a minibatch setting, i.e., (1-gamma) * oldMetric + gamma newMetric. Should be set to 1/#minibatch

--- a/init.lua
+++ b/init.lua
@@ -74,6 +74,7 @@ require('nnx.Balance')
 require('nnx.PushTable')
 require('nnx.PullTable')
 require('nnx.ZeroGrad')
+require('nnx.QDRiemaNNLinear')
 
 -- criterions:
 require('nnx.SuperCriterion')


### PR DESCRIPTION
This is a torch implementation (coded only in Lua), compatible with the GPU, of one of the algorithms presented in http://arxiv.org/abs/1602.08007. This class inherits from `Linear` and override the `accGradParameters` and the `reset` methods.